### PR TITLE
fix: CloudflareSpeedTestClient timeout issues by handling autoStart and custom timeouts properly

### DIFF
--- a/scripts/debug-measurements.js
+++ b/scripts/debug-measurements.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { CloudflareSpeedTestClient } from '../dist/clients/cloudflare.js';
+
+function debugMeasurements() {
+  console.log('🔍 Debugging measurements configuration\n');
+  
+  const client = new CloudflareSpeedTestClient();
+  
+  // Check what getTestMeasurements returns for 'latency'
+  console.log('📋 Measurements for type "latency":');
+  const latencyMeasurements = client.getTestMeasurements('latency');
+  console.log(JSON.stringify(latencyMeasurements, null, 2));
+  
+  console.log('\n📋 Config speedTestConfig measurements:');
+  console.log('Length:', client.config.speedTestConfig.measurements?.length || 0);
+  if (client.config.speedTestConfig.measurements) {
+    console.log('Types:', client.config.speedTestConfig.measurements.map(m => m.type));
+  }
+  
+  console.log('\n🧪 Simulating runSpeedTest config creation...');
+  const config = {
+    ...client.config.speedTestConfig
+  };
+  console.log('Before override - measurements length:', config.measurements?.length || 0);
+  
+  const options = { type: 'latency' };
+  if (options.type && options.type !== 'full') {
+    config.measurements = client.getTestMeasurements(options.type);
+  }
+  console.log('After override - measurements length:', config.measurements?.length || 0);
+  console.log('After override - measurements:', JSON.stringify(config.measurements, null, 2));
+}
+
+debugMeasurements();

--- a/scripts/test-autostart.js
+++ b/scripts/test-autostart.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import SpeedTest from '@cloudflare/speedtest';
+
+async function testAutoStart() {
+  console.log('🧪 Testing autoStart behavior\n');
+  
+  const config1 = {
+    measurements: [{ type: 'latency', numPackets: 20 }],
+    autoStart: false
+  };
+  
+  const config2 = {
+    measurements: [{ type: 'latency', numPackets: 20 }],
+    // autoStart not specified (defaults to true?)
+  };
+  
+  console.log('Test 1: autoStart: false');
+  await testConfig(config1, 'autoStart false');
+  
+  console.log('\nTest 2: autoStart not specified');
+  await testConfig(config2, 'autoStart default');
+}
+
+async function testConfig(config, name) {
+  console.log(`📊 Config: ${JSON.stringify(config)}`);
+  const startTime = Date.now();
+  
+  try {
+    const result = await Promise.race([
+      new Promise((resolve, reject) => {
+        const speedTest = new SpeedTest(config);
+
+        speedTest.onFinish = (results) => {
+          resolve(results);
+        };
+
+        speedTest.onError = (error) => {
+          reject(new Error(`SpeedTest error: ${error}`));
+        };
+        
+        // If autoStart is false, we might need to manually start
+        if (config.autoStart === false) {
+          console.log('   🔄 Manually starting speedtest (autoStart is false)...');
+          speedTest.play();
+        }
+      }),
+      
+      new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new Error(`Timeout after 8 seconds`));
+        }, 8000);
+      })
+    ]);
+
+    const duration = Date.now() - startTime;
+    console.log(`✅ ${name}: SUCCESS in ${duration}ms`);
+    
+    if (result.getUnloadedLatency) {
+      console.log(`   Latency: ${result.getUnloadedLatency()}ms`);
+    }
+
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    console.log(`❌ ${name}: FAILED after ${duration}ms - ${error.message}`);
+  }
+}
+
+testAutoStart().catch(console.error);

--- a/scripts/test-cloudflare-api.js
+++ b/scripts/test-cloudflare-api.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/**
+ * Direct test of @cloudflare/speedtest library
+ * Tests the raw library without our CloudflareSpeedTestClient wrapper
+ * This will isolate whether timeout issues are from the library itself or our code
+ */
+
+import SpeedTest from '@cloudflare/speedtest';
+
+async function testDirectCloudflareLibrary() {
+  console.log('🚀 Testing @cloudflare/speedtest Library DIRECTLY\n');
+  console.log('🎯 Bypassing our CloudflareSpeedTestClient wrapper to isolate the issue\n');
+
+  // Test 1: Basic latency test (same config as our getTestMeasurements for 'latency')
+  console.log('⚡ Test 1: Basic latency test (20 packets)...');
+  await runDirectSpeedTest('Basic Latency', {
+    measurements: [
+      { type: 'latency', numPackets: 20 }
+    ]
+  }, 20000); // 20 second timeout
+
+  console.log('\n' + '='.repeat(60) + '\n');
+
+  // Add delay to prevent rate limiting
+  console.log('⏳ Waiting 3 seconds before next test to prevent rate limiting...');
+  await new Promise(resolve => setTimeout(resolve, 3000));
+
+  // Test 2: Simple latency test (fewer packets)
+  console.log('⚡ Test 2: Simple latency test (5 packets)...');
+  await runDirectSpeedTest('Simple Latency', {
+    measurements: [
+      { type: 'latency', numPackets: 5 }
+    ]
+  }, 15000); // 15 second timeout
+
+  console.log('\n' + '='.repeat(60) + '\n');
+
+  // Add delay to prevent rate limiting
+  console.log('⏳ Waiting 3 seconds before next test to prevent rate limiting...');
+  await new Promise(resolve => setTimeout(resolve, 3000));
+
+  // Test 3: Minimal latency test (1 packet)
+  console.log('⚡ Test 3: Minimal latency test (1 packet)...');
+  await runDirectSpeedTest('Minimal Latency', {
+    measurements: [
+      { type: 'latency', numPackets: 1 }
+    ]
+  }, 10000); // 10 second timeout
+}
+
+async function runDirectSpeedTest(testName, config, timeoutMs) {
+  console.log(`📊 Configuration: ${JSON.stringify(config)}`);
+  console.log(`⏱️  Timeout: ${timeoutMs / 1000} seconds\n`);
+  
+  const startTime = Date.now();
+  
+  try {
+    const result = await Promise.race([
+      // Direct SpeedTest promise
+      new Promise((resolve, reject) => {
+        const speedTest = new SpeedTest(config);
+
+        speedTest.onFinish = (results) => {
+          resolve(results);
+        };
+
+        speedTest.onError = (error) => {
+          reject(new Error(`SpeedTest library error: ${error}`));
+        };
+
+        // Log any progress if available
+        if (speedTest.onProgress) {
+          speedTest.onProgress = (progress) => {
+            console.log(`   Progress: ${JSON.stringify(progress)}`);
+          };
+        }
+      }),
+      
+      // Timeout promise
+      new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new Error(`Manual timeout after ${timeoutMs / 1000} seconds`));
+        }, timeoutMs);
+      })
+    ]);
+
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+    
+    console.log(`✅ ${testName}: SUCCESS (took ${duration}ms)`);
+    
+    // Try to get results
+    try {
+      const summary = result.getSummary();
+      console.log(`   Latency: ${summary.latency || 'N/A'}ms`);
+      console.log(`   Jitter: ${summary.jitter || 'N/A'}ms`);
+      console.log(`   Download: ${summary.download || 'N/A'} Mbps`);
+    } catch (summaryError) {
+      console.log(`   Results summary error: ${summaryError.message}`);
+      
+      // Try alternative methods to get data
+      if (result.getUnloadedLatency) {
+        console.log(`   Unloaded Latency: ${result.getUnloadedLatency()}ms`);
+      }
+    }
+    
+    console.log(`\n💡 ${testName} CONCLUSION: Library works for this configuration`);
+
+  } catch (error) {
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+    
+    console.log(`❌ ${testName}: FAILED after ${duration}ms`);
+    console.log(`   Error: ${error.message}`);
+    
+    if (error.message.includes('Manual timeout')) {
+      console.log(`\n🔍 TIMEOUT ANALYSIS for ${testName}:`);
+      console.log(`   - Test ran for ${duration}ms`);
+      console.log(`   - Manual timeout was set to ${timeoutMs}ms`);
+      console.log('   - This suggests the library itself is taking too long');
+      console.log('   - This is likely a network/server issue, not a code issue');
+    } else {
+      console.log(`\n❌ ${testName} CONCLUSION: Library returned an error`);
+      console.log('   - This suggests an issue with the library or network connectivity');
+    }
+  }
+}
+
+testDirectCloudflareLibrary().catch(error => {
+  console.error('💥 Direct library test failed:', error);
+  process.exit(1);
+});

--- a/scripts/test-timeout-fix.js
+++ b/scripts/test-timeout-fix.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { CloudflareSpeedTestClient } from '../dist/clients/cloudflare.js';
+
+async function testTimeoutFix() {
+  console.log('🧪 Testing timeout fix for CloudflareSpeedTestClient');
+  
+  const client = new CloudflareSpeedTestClient({
+    timeouts: {
+      DEFAULT: 30000,
+      SPEED_TEST: 60000, // Set high default
+      CONNECTION_INFO: 30000
+    }
+  });
+  
+  console.log('\n⏱️  Testing latency with 5-second timeout...');
+  const startTime = Date.now();
+  
+  try {
+    // This should complete quickly (< 1 second based on memory analysis)
+    const results = await client.runSpeedTest({ 
+      type: 'latency', 
+      timeout: 5000  // 5 second timeout should be plenty
+    });
+    
+    const duration = Date.now() - startTime;
+    console.log(`✅ SUCCESS - Latency test completed in ${duration}ms`);
+    console.log(`   Latency: ${results.getUnloadedLatency()}ms`);
+    
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    console.log(`❌ FAILED after ${duration}ms - ${error.message}`);
+    console.log(`   Error code: ${error.code || 'unknown'}`);
+  }
+  
+  console.log('\n⏱️  Testing with very short 100ms timeout...');
+  const startTime2 = Date.now();
+  
+  try {
+    // This should timeout quickly
+    const results = await client.runSpeedTest({ 
+      type: 'latency', 
+      timeout: 100  // 100ms timeout - should definitely timeout
+    });
+    
+    const duration = Date.now() - startTime2;
+    console.log(`❌ FAILED - Should have timed out but completed in ${duration}ms`);
+    
+  } catch (error) {
+    const duration = Date.now() - startTime2;
+    if (error.message.includes('100ms')) {
+      console.log(`✅ SUCCESS - Correctly timed out after ${duration}ms with 100ms timeout`);
+    } else {
+      console.log(`⚠️  PARTIAL - Timed out after ${duration}ms but wrong message: ${error.message}`);
+    }
+  }
+}
+
+testTimeoutFix().catch(console.error);

--- a/scripts/test-wrapper-config.js
+++ b/scripts/test-wrapper-config.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import SpeedTest from '@cloudflare/speedtest';
+import { CloudflareSpeedTestClient } from '../dist/clients/cloudflare.js';
+
+async function testWithWrapperConfig() {
+  console.log('🧪 Testing with exact wrapper configuration\n');
+  
+  // Get the config from our wrapper
+  const client = new CloudflareSpeedTestClient();
+  
+  // Simulate what runSpeedTest does
+  const config = {
+    ...client.config.speedTestConfig
+  };
+  
+  const options = { type: 'latency' };
+  if (options.type && options.type !== 'full') {
+    config.measurements = client.getTestMeasurements(options.type);
+  }
+  
+  console.log('📊 Using config from wrapper:');
+  console.log(JSON.stringify(config, null, 2));
+  console.log();
+  
+  console.log('⚡ Running direct library test with wrapper config...');
+  const startTime = Date.now();
+  
+  try {
+    const result = await Promise.race([
+      // Direct SpeedTest promise with our wrapper's config
+      new Promise((resolve, reject) => {
+        const speedTest = new SpeedTest(config);
+
+        speedTest.onFinish = (results) => {
+          resolve(results);
+        };
+
+        speedTest.onError = (error) => {
+          reject(new Error(`SpeedTest library error: ${error}`));
+        };
+      }),
+      
+      // 10 second timeout for this test
+      new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new Error(`Manual timeout after 10 seconds`));
+        }, 10000);
+      })
+    ]);
+
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+    
+    console.log(`✅ SUCCESS: Direct library with wrapper config completed in ${duration}ms`);
+    
+    try {
+      const summary = result.getSummary();
+      console.log(`   Latency: ${summary.latency || 'N/A'}ms`);
+      console.log(`   Jitter: ${summary.jitter || 'N/A'}ms`);
+    } catch (summaryError) {
+      if (result.getUnloadedLatency) {
+        console.log(`   Unloaded Latency: ${result.getUnloadedLatency()}ms`);
+      }
+    }
+
+  } catch (error) {
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+    
+    console.log(`❌ FAILED after ${duration}ms: ${error.message}`);
+  }
+}
+
+testWithWrapperConfig().catch(console.error);

--- a/src/__tests__/cloudflare.test.ts
+++ b/src/__tests__/cloudflare.test.ts
@@ -14,14 +14,15 @@ global.fetch = jest.fn();
 
 describe('CloudflareSpeedTestClient', () => {
   let client: CloudflareSpeedTestClient;
-  let mockSpeedTest: { onFinish: jest.Mock; onError: jest.Mock };
+  let mockSpeedTest: { onFinish: jest.Mock; onError: jest.Mock; play: jest.Mock };
   let mockFetch: jest.MockedFunction<typeof fetch>;
 
   beforeEach(() => {
     mockFetch = jest.mocked(fetch);
     mockSpeedTest = {
       onFinish: jest.fn(),
-      onError: jest.fn()
+      onError: jest.fn(),
+      play: jest.fn()
     };
     
     const SpeedTest = require('@cloudflare/speedtest').default;


### PR DESCRIPTION
  1. ✅ Custom timeout parameters
  2. ✅ AutoStart configuration with speedTest.play()
  3. ✅ Removed unnecessary retry logic
  4. ✅ Performance matching direct library (~900ms for latency tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standalone scripts for debugging measurement configurations, testing auto-start options, timeout behavior, wrapper configurations, and direct library speed tests.

* **Bug Fixes**
  * Enhanced timeout handling to prevent multiple callbacks and ensured manual start of speed tests when auto-start is disabled.

* **Tests**
  * Updated test mocks to support manual start functionality.

* **Refactor**
  * Removed retry logic from speed test execution and added explicit timeout validation with configurable per-test timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->